### PR TITLE
feat: Add branch requirement for release process

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-Install Cargo release
+Install [Cargo release](https://github.com/crate-ci/cargo-release):
 
 ```bash
 cargo install cargo-release
@@ -10,7 +10,7 @@ cargo install cargo-release
 
 ## Actions
 
-1. Start of with a clean repo
+1. Start of with a clean repo on the master branch
 2. Dry-run the release for the next version, e.g.
     - `cargo release patch`
     - `cargo release minor`

--- a/release.toml
+++ b/release.toml
@@ -1,1 +1,2 @@
 publish = false  # Let the CI do the publishing
+allow-branch = ['master']


### PR DESCRIPTION
Accidentally made a release on an old feature branch so this will not let that happen next time.

Would be nice though to have a release branch process instead to not push directly to master...