### PR TITLE
Release pipeline changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,9 @@ jobs:
       - name: Get build cache
         uses: Swatinem/rust-cache@v2
       - name: Run Cargo Test
-        run: cargo test -r --all-targets --workspace
+        run: |
+          cargo build -r --all-targets --workspace
+          cargo test -r --all-targets --workspace
 
   docs:
     name: Build docs

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -103,28 +103,21 @@ jobs:
       - name: Package
         shell: bash
         run: |
-          ext=""
-          [[ "${{ matrix.name }}" == windows-* ]] && ext=".exe"
-          bin="target/${{ matrix.target }}/release/timecalc${ext}"
+          bin="target/${{ matrix.target }}/release/timecalc"
+          if [[ "${{ matrix.name }}" == windows-* ]]; then
+            bin="${bin}.exe"
+          fi
           version=$GITHUB_REF_NAME
-          dst="timecalc-${{ matrix.target }}-${version}"
-          mkdir "$dst"
-          mv "$bin" "$dst/"
-          cp README.md LICENSE "$dst/"
-      - name: Archive (tar)
-        if: '! startsWith(matrix.name, ''windows-'')'
-        shell: bash
-        run: |
-          version=$GITHUB_REF_NAME
-          dst="timecalc-${{ matrix.target }}-${version}"
-          tar cavf "$dst.tgz" "$dst"
-      - name: Archive (zip)
-        if: startsWith(matrix.name, 'windows-')
-        shell: bash
-        run: |
-          version=$GITHUB_REF_NAME
-          dst="timecalc-${{ matrix.target }}-${version}"
-          7z a "$dst.zip" "$dst"
+          outdir="timecalc-${{ matrix.target }}-${version}"
+          mkdir "${outdir}"
+          mv "${bin}" "${outdir}/"
+          cp README.md LICENSE "${outdir}/"
+
+          if [[ "${{ matrix.name }}" == windows-* ]]; then
+            7z a "${outdir}.zip" "${outdir}"
+          else
+            tar cavf "${outdir}.tgz" "${outdir}"
+          fi
       - name: Upload artifact to release draft
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -16,18 +16,39 @@ env:
   RUSTDOCFLAGS: -D warnings
 
 jobs:
+  set_version:
+    name: Set version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set_version_step.outputs.version }}
+    steps:
+      - name: Set version
+        id: set_version_step
+        run: |
+          version=""
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            version="${GITHUB_REF_NAME}"
+          else
+            version="${{ github.event.inputs.version }}"
+          fi
+          echo "version=${version#v}" >> $GITHUB_OUTPUT
+
   create_release_draft:
+    name: Create release draft
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    needs: set_version
     steps:
+      - name: Echo version
+        run: echo "Creating release for ${{ needs.set_version.outputs.version }}"
       - name: Checkout
         uses: actions/checkout@v4
       - name: Create release draft
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
+          name: ${{ needs.set_version.outputs.version }}
           draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,6 +95,9 @@ jobs:
             cross: false
 
     name: Binaries for ${{ matrix.name }}
+    needs:
+      - set_version
+      - create_release_draft
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
@@ -107,8 +131,7 @@ jobs:
           if [[ "${{ matrix.name }}" == windows-* ]]; then
             bin="${bin}.exe"
           fi
-          version=$GITHUB_REF_NAME
-          outdir="timecalc-${{ matrix.target }}-${version}"
+          outdir="timecalc-${{ matrix.target }}-${{ needs.set_version.outputs.version }}"
           mkdir "${outdir}"
           mv "${bin}" "${outdir}/"
           cp README.md LICENSE "${outdir}/"
@@ -122,7 +145,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
+          name: ${{ needs.set_version.outputs.version }}
           draft: true
           files: |
             timecalc-*.tgz

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -131,7 +131,7 @@ jobs:
           if [[ "${{ matrix.name }}" == windows-* ]]; then
             bin="${bin}.exe"
           fi
-          outdir="timecalc-${{ matrix.target }}-${{ needs.set_version.outputs.version }}"
+          outdir="timecalc-${{ needs.set_version.outputs.version }}-${{ matrix.target }}-"
           mkdir "${outdir}"
           mv "${bin}" "${outdir}/"
           cp README.md LICENSE "${outdir}/"


### PR DESCRIPTION
- Remove 'v' prefix from build artifacts and release name
- Make the executable name to be timecalc-<version>-<target>
- Simplify packaging step